### PR TITLE
rails-4 compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -25,7 +25,7 @@ Redmine::Plugin.register :redmine_local_avatars do
   version '1.0.3'
 end
 
-receiver = ActionDispatch::Callbacks.method_defined?(:to_prepere) ? ActionDispatch::Callbacks : ActiveSupport::Reloader
+receiver = Object.const_defined?('ActiveSupport::Reloader') ?  ActiveSupport::Reloader : ActionDispatch::Callbacks
 receiver.to_prepare  do
 	require_dependency 'project'
 	require_dependency 'principal'


### PR DESCRIPTION
Reversed the check to prevent 'NameError: uninitialized constant ActiveSupport::Reloader' with rails-4.x
There was a typo in the method check, too.

I did not check the code with rails-5.x. It builds an runs with rails-4.x without any problem.